### PR TITLE
New env settings for broker, producer, and streams

### DIFF
--- a/kaspr/__init__.py
+++ b/kaspr/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.5.17"
+__version__ = "0.5.18"
 
 from .core.app import KasprApp
 from .scheduler.manager import MessageScheduler

--- a/kaspr/app.py
+++ b/kaspr/app.py
@@ -15,37 +15,11 @@ app = KasprApp(
     origin="kaspr",
     store="rocksdb://",
     processing_guarantee="exactly_once",
-    # How often we commit messages that have been fully processed (acked).
-    broker_commit_interval=timedelta(seconds=2),
-    broker_commit_every=500,  # 2000,
-    # How long to wait for a node to finish rebalancing before the broker
-    # will consider it dysfunctional and remove it from the cluster.
-    # Increase this if you experience the cluster being in a state of
-    # constantly rebalancing, but make sure you also increase the
-    # broker_heartbeat_interval at the same time.
-    broker_session_timeout=120,
-    # Kafka client request timeout
-    broker_request_timeout=180,
-    # How often we send heartbeats to the broker, and also how often we
-    # expect to receive heartbeats from the broker.
-    broker_heartbeat_interval=9,
     # How long time it takes before we warn that the Kafka commit offset
     # has not advanced (only when processing messages).
     broker_commit_livelock_soft_timeout=timedelta(seconds=30),
     # The number of acknowledgments the producer requires the leader to
     # have received before considering a request complete (0,1,-1)
-    producer_acks=-1,
-    # Time to wait before continuing after rebalance
-    # To prevent issues with premature processing
-    stream_recovery_delay=timedelta(seconds=20),
-    # This setting controls whether the worker should wait for the currently
-    # processing task in an agent to complete before rebalancing or shutting down.
-    # On rebalance/shut down we clear the stream buffers. Those events will be
-    # reprocessed after the rebalance anyway, but we may have already started
-    # processing one event in every agent, and if we rebalance we will process that event again.
-    stream_wait_empty=True,
-    # The maximum number of records returned in a single call to poll()
-    broker_max_poll_records=100,
     table_cleanup_interval=10,
     Agent="kaspr.core.agent.KasprAgent",
     Table="kaspr.core.table.KasprTable",


### PR DESCRIPTION
Adds the following new environment variables:

#: Kafka client request timeout.
#: Note: The request timeout must not be less than the broker_session_timeout.
BROKER_REQUEST_TIMEOUT = int(_getenv("BROKER_REQUEST_TIMEOUT", 180))

#: Commit offset every n messages.
#: See also broker_commit_interval, which is how frequently we commit on a timer when 
#: there are few messages being received.
BROKER_COMMIT_EVERY = int(_getenv("BROKER_COMMIT_EVERY", 10_000))

#: How often we commit messages that have been fully processed (acked).
BROKER_COMMIT_INTERVAL = int(_getenv("BROKER_COMMIT_INTERVAL", 2.8))

#: How often we send heartbeats to the broker, and also how often we expect to receive heartbeats from the broker.
#: If any of these time out, you should increase this setting.
BROKER_HEARTBEAT_INTERVAL = int(_getenv("BROKER_HEARTBEAT_INTERVAL", 3.0))

#: How long to wait for a node to finish rebalancing before the broker will consider it 
#: dysfunctional and remove it from the cluster.
#: Increase this if you experience the cluster being in a state of constantly rebalancing,
#: but make sure you also increase the broker_heartbeat_interval at the same time.
#: Note: The session timeout must not be greater than the broker_request_timeout.
BROKER_SESSION_TIMEOUT = int(_getenv("BROKER_SESSION_TIMEOUT", 120))

#: The maximum number of records returned in a single call to poll(). 
# If you find that your application needs more time to process messages you may want to
# adjust broker_max_poll_records to tune the number of records that must be handled on 
# every loop iteration.
BROKER_MAX_POLL_RECORDS = int(_getenv("BROKER_MAX_POLL_RECORDS", 100))

#: The maximum allowed time (in seconds) between calls to consume messages If this interval
#: is exceeded the consumer is considered failed and the group will rebalance in order to 
#: reassign the partitions to another consumer group member. If API methods block waiting 
#: for messages, that time does not count against this timeout.
#: See KIP-62 for technical details.
BROKER_MAX_POLL_INTERVAL = int(_getenv("BROKER_MAX_POLL_INTERVAL", 1000.0))

#: The number of acknowledgments the producer requires the leader to have received 
#: before considering a request complete. This controls the durability of records 
#: that are sent. The following settings are common: 
#: 0: Producer will not wait for any acknowledgment from the server at all. The message 
#: will immediately be considered sent. (Not recommended)
#; 1: The broker leader will write the record to its local log but will respond without 
#: awaiting full acknowledgment from all followers. In this case should the leader fail 
#: immediately after acknowledging the record but before the followers have replicated it
#:  then the record will be lost.
#: -1: The broker leader will wait for the full set of in-sync replicas to acknowledge 
#: the record. This guarantees that the record will not be lost as long as at least one
#: in-sync replica remains alive. This is the strongest available guarantee.
PRODUCER_ACKS = int(_getenv("PRODUCER_ACKS", -1))

#: This setting control back pressure to streams and agents reading from streams.
#: If set to 4096 (default) this means that an agent can only keep at most 4096 
#: unprocessed items in the stream buffer. Essentially this will limit the number 
#: of messages a stream can “prefetch”. Higher numbers gives better throughput, but
#: do note that if your agent sends messages or update tables (which sends changelog
#: messages). This means that if the buffer size is large, the broker_commit_interval
#: or broker_commit_every settings must be set to commit frequently, avoiding back 
#: pressure from building up. A buffer size of 131_072 may let you process over 30,000
#: events a second as a baseline, but be careful with a buffer size that large when you
#: also send messages or update tables.
STREAM_BUFFER_MAXSIZE = int(_getenv("STREAM_BUFFER_MAXSIZE", 4096))

#: Number of seconds to sleep before continuing after rebalance. We wait for a bit to allow
#: for more nodes to join/leave before starting recovery tables and then processing streams.
#: This to minimize the chance of errors rebalancing loops.
STREAM_RECOVERY_DELAY = int(_getenv("STREAM_RECOVERY_DELAY", 10.0))

#: This setting controls whether the worker should wait for the currently processing task in 
#: an agent to complete before rebalancing or shutting down. On rebalance/shut down we clear
#: the stream buffers. Those events will be reprocessed after the rebalance anyway, but we may
#: have already started processing one event in every agent, and if we rebalance we will process
#: that event again. By default we will wait for the currently active tasks, but if your streams
#: are idempotent you can disable it using this setting.
STREAM_WAIT_EMPTY = bool(_getenv("STREAM_WAIT_EMPTY", True))