### PR TITLE
Bump version of faust to `v1.16.3`

### DIFF
--- a/kaspr/__init__.py
+++ b/kaspr/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.6.3"
+__version__ = "0.6.4"
 
 from .core.app import KasprApp
 from .scheduler.manager import MessageScheduler

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 pytz
 pyyaml==6.0
-twm-faust[rocksdict,prometheus]>=1.16.2,<1.17.0
+twm-faust[rocksdict,prometheus]>=1.16.3,<1.17.0
 python-benedict==0.33.2
 marshmallow==3.21.3
 mmh3==5.1.0


### PR DESCRIPTION
* This version of faust will crash the app on a partition assignment mismatch event instead of hanging.