### PR TITLE
Add KasprPartitionAssignor

### DIFF
--- a/kaspr/__init__.py
+++ b/kaspr/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.6.6"
+__version__ = "0.6.7"
 
 from .core.app import KasprApp
 from .scheduler.manager import MessageScheduler

--- a/kaspr/app.py
+++ b/kaspr/app.py
@@ -26,6 +26,7 @@ app = KasprApp(
     GlobalTable="kaspr.core.table.KasprGlobalTable",
     Stream="kaspr.core.stream.KasprStream",
     LeaderAssignor="kaspr.core.leader_assignor.KasprLeaderAssignor",
+    PartitionAssignor="kaspr.core.partition_assignor.KasprPartitionAssignor",
 )
 
 app.monitor = PrometheusMonitor(

--- a/kaspr/core/partition_assignor.py
+++ b/kaspr/core/partition_assignor.py
@@ -1,0 +1,15 @@
+# failfast_assignor.py
+import os
+import asyncio
+from faust.assignor import PartitionAssignor as BaseAssignor
+
+EXIT_CODE = 42  # any non-zero
+
+class KasprPartitionAssignor(BaseAssignor):
+    def on_assignment(self, *args, **kwargs):
+        try:
+            return super().on_assignment(*args, **kwargs)
+        except AssertionError as e:
+            self.app.log.error("Faust assignment assertion failed: %r", e, exc_info=True)
+            self.app.log.error("Exiting with code %d", EXIT_CODE)
+            os._exit(EXIT_CODE)


### PR DESCRIPTION
Introduces KasprPartitionAssignor in kaspr.core.partition_assignor, which overrides on_assignment to fail fast on assertion errors. Registers the new assignor in kaspr/app.py and bumps the package version to 0.6.7.