### PR TITLE
Fix error response in WebViewProcessorSpec

### DIFF
--- a/kaspr/__init__.py
+++ b/kaspr/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.6.8"
+__version__ = "0.6.9"
 
 from .core.app import KasprApp
 from .scheduler.manager import MessageScheduler

--- a/kaspr/types/models/webview/processor.py
+++ b/kaspr/types/models/webview/processor.py
@@ -73,7 +73,7 @@ class WebViewProcessorSpec(SpecComponent):
                     # a web response, so we return the last successful value.
                     return self.response.build_success(web, response_values[-1])
                 else:
-                    return self.response.build_error(web)
+                    return self.response.build_success(web)
 
             except Exception as ex:
                 error = KasprProcessingError(


### PR DESCRIPTION
Changed the response for failed webview processing to return a success instead of an error. Also bumped the package version to 0.6.9.