### PR TITLE
Add status blueprint with health endpoint

### DIFF
--- a/kaspr/__init__.py
+++ b/kaspr/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.6.11"
+__version__ = "0.6.12"
 
 from .core.app import KasprApp
 from .scheduler.manager import MessageScheduler

--- a/kaspr/app.py
+++ b/kaspr/app.py
@@ -33,3 +33,6 @@ app.monitor = PrometheusMonitor(
     app,
     pattern=f"{app.conf.web_metrics_base_path}/metrics",
 )
+
+# Add web endpoints
+app.web.blueprints.add('/status', 'kaspr.blueprints.status.blueprint')

--- a/kaspr/blueprints/status.py
+++ b/kaspr/blueprints/status.py
@@ -1,0 +1,38 @@
+"""HTTP endpoint showing health/status of various components the app."""
+
+from collections import defaultdict
+from typing import List, MutableMapping, Set
+from faust import web
+from faust.types.tuples import TP
+
+__all__ = ["Status", "blueprint"]
+
+TPMap = MutableMapping[str, List[int]]
+
+blueprint = web.Blueprint("status")
+
+@blueprint.route("/", name="status")
+class Status(web.View):
+    """App status information."""
+
+    @classmethod
+    def _topic_grouped(cls, assignment: Set[TP]) -> TPMap:
+        tps: MutableMapping[str, List[int]] = defaultdict(list)
+        for tp in sorted(assignment):
+            tps[tp.topic].append(tp.partition)
+        return dict(tps)
+
+    async def get(self, request: web.Request) -> web.Response:
+        """Return current app state as a JSON response."""
+        assignor = self.app.assignor
+        return self.json(
+            {
+                "rebalancing": self.app.rebalancing,
+                "recovering": self.app.tables.recovery.in_recovery,
+                "assignment": {
+                    "actives": self._topic_grouped(assignor.assigned_actives()),
+                    "standbys": self._topic_grouped(assignor.assigned_standbys()),
+                },
+                "table_metadata": self.app.router.tables_metadata()
+            }
+        )


### PR DESCRIPTION
* Introduces a new /status HTTP endpoint via a blueprint to expose application health and status information, including rebalancing state, recovery status, partition assignments, and table metadata.
* Bumps version to 0.6.12.