### PR TITLE
Fix: use janitor partitions

### DIFF
--- a/kaspr/__init__.py
+++ b/kaspr/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.10.0"
+__version__ = "0.10.1"
 
 from .core.app import KasprApp
 from .scheduler.manager import MessageScheduler

--- a/kaspr/scheduler/manager.py
+++ b/kaspr/scheduler/manager.py
@@ -201,8 +201,8 @@ class MessageScheduler(MessageSchedulerT, Service):
         """
         tasks = []
         self.log.info("Waiting for janitors...")
-        for partition in self.dispatcher_partitions:
-            tasks.append(self._dispatchers[partition].wait_empty())
+        for partition in self.janitor_partitions:
+            tasks.append(self._janitors[partition].wait_empty())
         if tasks:
             await asyncio.gather(*tasks)
 
@@ -461,7 +461,7 @@ class MessageScheduler(MessageSchedulerT, Service):
                         checkpoint.time_key,
                         checkpoint.sequence,
                         prettydate(checkpoint),
-                        locdiff(dispatcher.highwater, checkpoint),
+                        locdiff(janitor.highwater, checkpoint),
                     ]
                 )
             )


### PR DESCRIPTION
Update package version to 0.10.1 and fix MessageScheduler to reference janitors instead of dispatchers. Iterate over self.janitor_partitions and await self._janitors[partition].wait_empty(), and use janitor.highwater when computing locdiff. Changes in kaspr/__init__.py and kaspr/scheduler/manager.py correct incorrect dispatcher references that caused wrong waiting/highwater behavior.