### PR TITLE
Bump version and handle janitor highwater None

### DIFF
--- a/kaspr/__init__.py
+++ b/kaspr/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.10.1"
+__version__ = "0.10.2"
 
 from .core.app import KasprApp
 from .scheduler.manager import MessageScheduler

--- a/kaspr/scheduler/manager.py
+++ b/kaspr/scheduler/manager.py
@@ -453,6 +453,7 @@ class MessageScheduler(MessageSchedulerT, Service):
         for partition, janitor in self._janitors.items():
             pt = PT(SchedulerPart.janitor, partition)
             checkpoint = self.checkpoints.get(pt, default=janitor.default_checkpoint)
+            janitor_highwater = janitor.highwater
             _data.append(
                 tuple(
                     [
@@ -461,7 +462,9 @@ class MessageScheduler(MessageSchedulerT, Service):
                         checkpoint.time_key,
                         checkpoint.sequence,
                         prettydate(checkpoint),
-                        locdiff(janitor.highwater, checkpoint),
+                        locdiff(janitor_highwater, checkpoint)
+                        if janitor_highwater is not None
+                        else "-",
                     ]
                 )
             )
@@ -504,6 +507,7 @@ class MessageScheduler(MessageSchedulerT, Service):
         for janitor in self._janitors.values():
             last = janitor.last_location
             if last:
+                janitor_highwater = janitor.highwater
                 _data.append(
                     tuple(
                         [
@@ -512,7 +516,9 @@ class MessageScheduler(MessageSchedulerT, Service):
                             last.time_key,
                             last.sequence,
                             prettydate(last),
-                            locdiff(janitor.highwater, last),
+                            locdiff(janitor_highwater, last)
+                            if janitor_highwater is not None
+                            else "-",
                             self.monitor.janitor_state(janitor).messages_removed,
                             "-",
                             "-",


### PR DESCRIPTION
Bump package version to 0.10.2. In MessageScheduler, cache janitor.highwater to a local variable and guard calls to locdiff so that when highwater is None a '-' is shown instead of passing None to locdiff (applies to janitor listings and last-location summaries). This prevents errors and makes the output clearer when highwater is missing.