### PR TITLE
Revert default key serializer to raw

### DIFF
--- a/kaspr/__init__.py
+++ b/kaspr/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.10.3"
+__version__ = "0.10.4"
 
 from .core.app import KasprApp
 from .scheduler.manager import MessageScheduler

--- a/kaspr/types/settings.py
+++ b/kaspr/types/settings.py
@@ -298,7 +298,7 @@ WEB_METRICS_BASE_PATH = _getenv("WEB_METRICS_BASE_PATH", "")
 DEFINITIONS_DIR = _getenv("DEFINITIONS_DIR", "builders")
 
 #: Serializer used for keys by default when no serializer is specified.
-KEY_SERIALIZER = _getenv("KEY_SERIALIZER", "json")
+KEY_SERIALIZER = _getenv("KEY_SERIALIZER", "raw")
 
 #: Serializer used for values by default when no serializer is specified.
 VALUE_SERIALIZER = _getenv("VALUE_SERIALIZER", "json")


### PR DESCRIPTION
Update package version to 0.10.4 and change the default KEY_SERIALIZER from "json" to "raw" in settings. This makes keys use the raw serializer by default (avoiding JSON encoding), and reflects the change in the package version.