### PR TITLE
Bump version and remove debug prints

### DIFF
--- a/kaspr/__init__.py
+++ b/kaspr/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.10.4"
+__version__ = "0.10.5"
 
 from .core.app import KasprApp
 from .scheduler.manager import MessageScheduler

--- a/kaspr/scheduler/manager.py
+++ b/kaspr/scheduler/manager.py
@@ -893,7 +893,7 @@ class MessageScheduler(MessageSchedulerT, Service):
                 headers.update(scheduler_headers)
                 _partition = self._request_partition(actions_topic, request_id)
                 send_kwargs = {"partition": _partition} if _partition is not None else {}
-                print(f"Distributing message with action {_action} to partition {_partition}")
+
                 await actions_topic.send(
                     key=event.message.key,
                     value=event.message.value,
@@ -978,7 +978,7 @@ class MessageScheduler(MessageSchedulerT, Service):
             headers.update(scheduler_headers)
             _partition = self._request_partition(actions_topic, request_id)
             send_kwargs = {"partition": _partition} if _partition is not None else {}
-            print(f"Distributing message with action {_action} to partition {_partition}")
+
             await actions_topic.send(
                 key=event.message.key,
                 value=event.message.value,


### PR DESCRIPTION
Bump package version to 0.10.5 and remove leftover debug print statements in MessageScheduler to avoid noisy output. Changes: kaspr/__init__.py (version update to 0.10.5) and kaspr/scheduler/manager.py (removed debug prints before sending to actions_topic).